### PR TITLE
revert some pyston changes now that we have ob_refcnt

### DIFF
--- a/from_cpython/Modules/_io/textio.c
+++ b/from_cpython/Modules/_io/textio.c
@@ -305,9 +305,8 @@ _PyIncrementalNewlineDecoder_decode(PyObject *_self,
     if (!final) {
         if (output_len > 0
             && PyUnicode_AS_UNICODE(output)[output_len - 1] == '\r') {
-            // Pyston change:
-            // if (Py_REFCNT(output) == 1) {
-            if (0) {
+
+            if (Py_REFCNT(output) == 1) {
                 if (PyUnicode_Resize(&output, output_len - 1) < 0)
                     goto error;
             }
@@ -406,9 +405,7 @@ _PyIncrementalNewlineDecoder_decode(PyObject *_self,
             PyObject *translated = NULL;
             Py_UNICODE *out_str;
             Py_UNICODE *in, *out, *end;
-            // Pyston change
-            // if (Py_REFCNT(output) != 1) {
-            if (1) {
+            if (Py_REFCNT(output) != 1) {
                 /* We could try to optimize this so that we only do a copy
                    when there is something to translate. On the other hand,
                    most decoders should only output non-shared strings, i.e.
@@ -416,7 +413,7 @@ _PyIncrementalNewlineDecoder_decode(PyObject *_self,
                 translated = PyUnicode_FromUnicode(NULL, len);
                 if (translated == NULL)
                     goto error;
-                // assert(Py_REFCNT(translated) == 1); Pyston change
+                assert(Py_REFCNT(translated) == 1);
                 memcpy(PyUnicode_AS_UNICODE(translated),
                        PyUnicode_AS_UNICODE(output),
                        len * sizeof(Py_UNICODE));
@@ -1801,9 +1798,7 @@ _textiowrapper_readline(textio *self, Py_ssize_t limit)
         /* Our line ends in the current buffer */
         self->decoded_chars_used = endpos - offset_to_buffer;
         if (start > 0 || endpos < PyUnicode_GET_SIZE(line)) {
-            // Pyston change:
-            // if (start == 0 && Py_REFCNT(line) == 1) {
-            if (0) {
+            if (start == 0 && Py_REFCNT(line) == 1) {
                 if (PyUnicode_Resize(&line, endpos) < 0)
                     goto error;
             }


### PR DESCRIPTION
this was the only thing I found while looking thru the refcounting merge which looked like it can get cleaned up.